### PR TITLE
block all gestures(temporal)

### DIFF
--- a/src/core/meta-gesture-tracker.c
+++ b/src/core/meta-gesture-tracker.c
@@ -172,7 +172,7 @@ meta_gesture_tracker_class_init (MetaGestureTrackerClass *klass)
                   G_TYPE_NONE, 2, G_TYPE_POINTER, G_TYPE_UINT);
 }
 
-static void
+static gboolean
 autodeny_sequence (gpointer user_data)
 {
   MetaSequenceInfo *info = user_data;
@@ -183,6 +183,7 @@ autodeny_sequence (gpointer user_data)
                                              META_SEQUENCE_REJECTED);
 
   info->autodeny_timeout_id = 0;
+  return G_SOURCE_REMOVE;
 }
 
 static MetaSequenceInfo *
@@ -200,7 +201,7 @@ meta_sequence_info_new (MetaGestureTracker *tracker,
   info->tracker = tracker;
   info->sequence = clutter_event_get_event_sequence (event);
   info->state = META_SEQUENCE_NONE;
-  info->autodeny_timeout_id = g_timeout_add_once (ms, autodeny_sequence, info);
+  info->autodeny_timeout_id = g_timeout_add (ms, autodeny_sequence, info);
 
   clutter_event_get_coords (event, &info->start_x, &info->start_y);
 
@@ -284,15 +285,9 @@ gesture_begin_cb (ClutterGestureAction *gesture,
                   ClutterActor         *actor,
                   MetaGestureTracker   *tracker)
 {
-  MetaGestureTrackerPrivate *priv;
-
-  priv = meta_gesture_tracker_get_instance_private (tracker);
-
-  if (!g_list_find (priv->listeners, gesture) &&
-      meta_gesture_tracker_set_state (tracker, META_SEQUENCE_ACCEPTED))
-    priv->listeners = g_list_prepend (priv->listeners, gesture);
-
-  return TRUE;
+  g_message("Blocked gesture in gesture_begin_cb()");
+  // Reject the gesture sequence right away
+  return FALSE;
 }
 
 static void
@@ -327,11 +322,12 @@ gesture_cancel_cb (ClutterGestureAction *gesture,
     }
 }
 
-static void
+static gboolean
 cancel_and_unref_gesture_cb (ClutterGestureAction *action)
 {
   clutter_gesture_action_cancel (action);
   g_object_unref (action);
+  return G_SOURCE_REMOVE;
 }
 
 static void
@@ -342,7 +338,7 @@ clear_gesture_data (GestureActionData *data)
   g_clear_signal_handler (&data->gesture_cancel_id, data->gesture);
 
   /* Defer cancellation to an idle, as it may happen within event handling */
-  g_idle_add_once ((GSourceOnceFunc) cancel_and_unref_gesture_cb, data->gesture);
+  g_idle_add ((GSourceFunc) cancel_and_unref_gesture_cb, data->gesture);
 }
 
 static void


### PR DESCRIPTION
Pulling changes from the first iteration of the gestures block; at the time all gestures are getting blocked by the mutter modification.

Future implementation need to tackle this and try to filter how the gestures are getting blocked